### PR TITLE
Custom Unicode Dividers

### DIFF
--- a/ito.js
+++ b/ito.js
@@ -45,6 +45,14 @@ var ito = {
 
     return formattedCustomList;
 
+  },
+
+  _formatDivider: function(dividerType) {
+    return '\n //============================== \n';
+  },
+
+  _formatCustomDivider: function(dividerType) {
+    return '\n //=============================' + dividerType + ' \n';
   }
 };
 

--- a/tests/test-ito.js
+++ b/tests/test-ito.js
@@ -68,3 +68,28 @@ describe('._formatCustomList', function() {
     assert.strictEqual(starList, expectedStarList, 'Custom Star List was not properly formatted.');
   });
 });
+
+describe('._formatDivider', function() {
+  it('should return a formatted divider', function() {
+    var divider         = ito._formatDivider();
+    var expectedDivider = '\n //============================== \n';
+
+    assert.strictEqual(divider, expectedDivider, 'Divider was not properly formatted.');
+  });
+});
+
+describe('._formatCustomDivider', function() {
+  it('should return a formatted divider with a heart', function() {
+    var heartDivider         = ito._formatCustomDivider('\u2665');
+    var expectedHeartDivider = '\n //=============================\u2665 \n';
+
+    assert.strictEqual(heartDivider, expectedHeartDivider, 'Heart Divider was not properly formatted.');
+  });
+
+  it('should return a formatted divider with a star', function() {
+    var starDivider         = ito._formatCustomDivider('\u2605');
+    var expectedStarDivider = '\n //=============================\u2605 \n';
+
+    assert.strictEqual(starDivider, expectedStarDivider, 'Star Divider was not properly formatted.');
+  });
+});


### PR DESCRIPTION
Added `._formatCustomDividers` which accepts a unicode character to append the end of a divider.
Added `._formatDivider` which just returns a simple divider.

:star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2:
