### PR TITLE
Dividers now have a set length of 30

### DIFF
--- a/ito.js
+++ b/ito.js
@@ -48,11 +48,19 @@ var ito = {
   },
 
   _formatDivider: function(dividerType) {
-    return '\n //============================== \n';
+    var dividerLength    = 30;
+    var dividerBars      = new Array(dividerLength + 1).join('=');
+    var formattedDivider = '\n //' + dividerBars + ' \n';
+
+    return formattedDivider;
   },
 
   _formatCustomDivider: function(dividerType) {
-    return '\n //=============================' + dividerType + ' \n';
+    var dividerLength    = 30 - dividerType.length;
+    var dividerBars      = new Array(dividerLength + 1).join('=');
+    var formattedCustomDivider = '\n //' + dividerBars + dividerType + ' \n';
+
+    return formattedCustomDivider;
   }
 };
 

--- a/tests/test-ito.js
+++ b/tests/test-ito.js
@@ -87,9 +87,16 @@ describe('._formatCustomDivider', function() {
   });
 
   it('should return a formatted divider with a star', function() {
-    var starDivider         = ito._formatCustomDivider('\u2605');
-    var expectedStarDivider = '\n //=============================\u2605 \n';
+    var starDivider         = ito._formatCustomDivider('\u2605\u2605');
+    var expectedStarDivider = '\n //============================\u2605\u2605 \n';
 
     assert.strictEqual(starDivider, expectedStarDivider, 'Star Divider was not properly formatted.');
+  });
+
+  it('should return a formatted divider with a string "loading modules"', function() {
+    var stringDivider         = ito._formatCustomDivider('loading modules');
+    var expectedStringDivider = '\n //===============loading modules \n';
+
+    assert.strictEqual(stringDivider, expectedStringDivider, 'String Divider was not properly formatted.');
   });
 });


### PR DESCRIPTION
Sooooo :fearful:. I realized that with the previous divider implementation I wasn't following the pattern where I return a variable that is the formatted string. 

Also I wanted to set a standard length for the dividers so it can be easily changed.

:white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower::white_flower:
